### PR TITLE
Ignore unreachable hosts

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.swp
-
+.direnv/

--- a/build_inventory.py
+++ b/build_inventory.py
@@ -11,117 +11,132 @@ from typing import Iterable, Mapping, Set
 # Regex to match the directive
 #   (x-nixos:rebuild:relay_port:XXXX)
 # in commit messages, signaling to include the host at port XXXX at the relays
-commit_directive_regex = re.compile(
-  r'\(x-nixos:rebuild:relay_port:([1-9][0-9]{,4})\)'
-)
+commit_directive_regex = re.compile(r"\(x-nixos:rebuild:relay_port:([1-9][0-9]{,4})\)")
+
 
 def configure_yaml(yaml):
-  yaml.SafeDumper.add_representer(
-    type(None),
-    lambda dumper, _: dumper.represent_scalar(u'tag:yaml.org,2002:null', '')
-  )
+    yaml.SafeDumper.add_representer(
+        type(None),
+        lambda dumper, _: dumper.represent_scalar("tag:yaml.org,2002:null", ""),
+    )
 
 
 def args_parser():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--sshrelay_domain',  type=str, dest='sshrelay_domain', required=True)
-  parser.add_argument('--sshrelay_user',    type=str, dest='sshrelay_user', required=True)
-  parser.add_argument('--sshrelay_port',    type=int, dest='sshrelay_port', required=True)
-  parser.add_argument('--fixedhosts',       type=str, dest='fixed_hosts', required=False, default="")
-  parser.add_argument('--fixedtunnelports', type=str, dest='fixed_ports', required=False, default="")
-  parser.add_argument('--eventlog',         type=str, dest='event_log',   required=True)
-  parser.add_argument('--keyfile',          type=str, dest='key_file',    required=True)
-  parser.add_argument('--timeout',          type=int, dest='time_out',    required=True)
-  parser.add_argument('--json', dest='use_json', action='store_true',     required=False)
-  return parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sshrelay_domain", type=str, dest="sshrelay_domain", required=True
+    )
+    parser.add_argument(
+        "--sshrelay_user", type=str, dest="sshrelay_user", required=True
+    )
+    parser.add_argument(
+        "--sshrelay_port", type=int, dest="sshrelay_port", required=True
+    )
+    parser.add_argument(
+        "--fixedhosts", type=str, dest="fixed_hosts", required=False, default=""
+    )
+    parser.add_argument(
+        "--fixedtunnelports", type=str, dest="fixed_ports", required=False, default=""
+    )
+    parser.add_argument("--eventlog", type=str, dest="event_log", required=True)
+    parser.add_argument("--keyfile", type=str, dest="key_file", required=True)
+    parser.add_argument("--timeout", type=int, dest="time_out", required=True)
+    parser.add_argument("--json", dest="use_json", action="store_true", required=False)
+    return parser
 
 
 def is_port(port: str) -> bool:
-  return port.isdigit() and (int(port) < 2**16)
+    return port.isdigit() and (int(port) < 2**16)
 
 
 def toInt(s: str) -> int:
-  return int(s)
+    return int(s)
 
 
 def get_ports(commit_message: str) -> Iterable[int]:
-  ms = commit_directive_regex.finditer(commit_message)
-  # Group 0 is the full matched expression, group 1 is the first subgroup
-  return map(toInt, filter(is_port, map(lambda m: m.group(1), ms)))
+    ms = commit_directive_regex.finditer(commit_message)
+    # Group 0 is the full matched expression, group 1 is the first subgroup
+    return map(toInt, filter(is_port, map(lambda m: m.group(1), ms)))
 
 
 def ports(event_log: str) -> Iterable[int]:
-  with open(event_log, 'r') as f:
-    data = json.load(f)
-  return { port
-           for commit in data.get("commits", [])
-           for port in get_ports(commit["message"]) }
+    with open(event_log, "r") as f:
+        data = json.load(f)
+    return {
+        port
+        for commit in data.get("commits", [])
+        for port in get_ports(commit["message"])
+    }
 
 
 def inventory_definition(tunnel_ports: Iterable[int]):
-  return { f"tunnelled_{port}": { "ansible_port": port } for port in tunnel_ports }
+    return {f"tunnelled_{port}": {"ansible_port": port} for port in tunnel_ports}
 
 
-def inventory(fixed_hosts: Set[str],
-              sshrelay_domain: str,
-              sshrelay_user: str,
-              sshrelay_port: int,
-              tunnel_ports: Set[int],
-              key_file: str,
-              time_out: int) -> Mapping:
-  return {
-    "all": {
-      "children": {
-        "direct_hosts": {
-          "hosts": { fixed_host: None for fixed_host in fixed_hosts }
-        },
-        "tunnelled": {
-          "hosts": inventory_definition(tunnel_ports),
-          "vars": {
-            "ansible_host": "localhost",
-            "ansible_ssh_common_args": f"-o 'ProxyCommand=ssh -W %h:%p " + \
-                                                            f"-i {key_file} " + \
-                                                            f"-p {sshrelay_port} " + \
-                                                            f"-o ConnectTimeout={time_out} " + \
-                                                             "-o StrictHostKeyChecking=yes " + \
-                                                            f"-l {sshrelay_user} " + \
-                                                            f"{sshrelay_domain}'"
-          }
+def inventory(
+    fixed_hosts: Set[str],
+    sshrelay_domain: str,
+    sshrelay_user: str,
+    sshrelay_port: int,
+    tunnel_ports: Set[int],
+    key_file: str,
+    time_out: int,
+) -> Mapping:
+    return {
+        "all": {
+            "children": {
+                "direct_hosts": {
+                    "hosts": {fixed_host: None for fixed_host in fixed_hosts}
+                },
+                "tunnelled": {
+                    "hosts": inventory_definition(tunnel_ports),
+                    "vars": {
+                        "ansible_host": "localhost",
+                        "ansible_ssh_common_args": "-o 'ProxyCommand=ssh -W %h:%p "
+                        + f"-i {key_file} "
+                        + f"-p {sshrelay_port} "
+                        + f"-o ConnectTimeout={time_out} "
+                        + "-o StrictHostKeyChecking=yes "
+                        + f"-l {sshrelay_user} "
+                        + f"{sshrelay_domain}'",
+                    },
+                },
+            },
+            "vars": {"ansible_user": "robot"},
         }
-      },
-      "vars": {
-        "ansible_user": "robot"
-      }
     }
-  }
 
 
 def write_inventory(inv: Mapping, use_json: bool) -> str:
-  if use_json:
-    return json.dumps(inv, indent=2)
-  else:
-    import yaml
-    configure_yaml(yaml)
-    return yaml.safe_dump(inv,                      # type: ignore
-                          indent=2,
-                          default_flow_style=False,
-                          width=120)
+    if use_json:
+        return json.dumps(inv, indent=2)
+    else:
+        import yaml
+
+        configure_yaml(yaml)
+        return yaml.safe_dump(inv, indent=2, default_flow_style=False, width=120)
 
 
 def main() -> None:
-  args = args_parser().parse_args()
-  tunnel_ports = set(itertools.chain(map(toInt, args.fixed_ports.split()),
-                                     ports(args.event_log)))
-  print(write_inventory(inventory(set(args.fixed_hosts.split()),
-                                  args.sshrelay_domain,
-                                  args.sshrelay_user,
-                                  args.sshrelay_port,
-                                  tunnel_ports,
-                                  args.key_file,
-                                  args.time_out),
-                        args.use_json))
+    args = args_parser().parse_args()
+    tunnel_ports = set(
+        itertools.chain(map(toInt, args.fixed_ports.split()), ports(args.event_log))
+    )
+    print(
+        write_inventory(
+            inventory(
+                set(args.fixed_hosts.split()),
+                args.sshrelay_domain,
+                args.sshrelay_user,
+                args.sshrelay_port,
+                tunnel_ports,
+                args.key_file,
+                args.time_out,
+            ),
+            args.use_json,
+        )
+    )
 
 
 if __name__ == "__main__":
-  main()
-
+    main()

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,9 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json
 ---
 - hosts: all
+  ignore_unreachable: true
   tasks:
   - name: Start the configured deployment service
     command: "sudo systemctl --system start {{ nixos_deploy_service }}"
     become: no
     async: 3600
     poll: 10
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686501370,
+        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.python3Packages.pyyaml
+            pkgs.python3Packages.types-pyyaml
+            pkgs.ansible
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Maintenance:
* Reformat python code
* Add a flake with a `devShell` and `.envrc` for easy development using direnv

Ignore unreachable hosts by default. Having hosts be offline is very common in the case of OCB and having commits labelled as failing because of this gives the impression that the CI failed, which is not helpful most of the time.
We still fail when there are actual errors, just not when some hosts are simply not online.